### PR TITLE
test: 게시글 레포 테스트

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,13 @@
+## h2 설정
+spring:
+    # H2 Setting Info (H2 Console에 접속하기 위한 설정정보 입력)
+    h2:
+        console:
+            enabled: true  # H2 Console을 사용할지 여부 (H2 Console은 H2 Database를 UI로 제공해주는 기능)
+            path: /h2-console  # H2 Console의 Path
+    # Database Setting Info (Database를 H2로 사용하기 위해 H2연결 정보 입력)
+    datasource:
+        driver-class-name: org.h2.Driver  # Database를 H2로 사용하겠다.
+        url: jdbc:h2:~/test  # H2 접속 정보
+        username: sa  # H2 접속 시 입력할 username 정보 (원하는 것으로 입력)
+        password:  # H2 접속 시 입력할 password 정보 (원하는 것으로 입력)

--- a/src/test/java/com/kt/board/BoardGenerator.java
+++ b/src/test/java/com/kt/board/BoardGenerator.java
@@ -1,0 +1,12 @@
+package com.kt.board;
+
+import java.util.UUID;
+
+import com.kt.board.domain.entity.BoardEntity;
+import com.kt.board.domain.entity.UserEntity;
+
+public class BoardGenerator {
+	public static BoardEntity generateBoard(UserEntity user) {
+		return BoardEntity.create("name_" + UUID.randomUUID(), user);
+	}
+}

--- a/src/test/java/com/kt/board/PostGenerator.java
+++ b/src/test/java/com/kt/board/PostGenerator.java
@@ -9,13 +9,33 @@ import com.kt.board.domain.entity.UserEntity;
 
 public class PostGenerator {
 
-	public static PostEntity generatePost(String postTitle, BoardEntity board, UserEntity user) {
+	public static PostEntity generatePost(BoardEntity board, UserEntity user) {
 		return PostEntity.create(
 			"title_" + UUID.randomUUID(),
 			"content_" + UUID.randomUUID(),
 			PostDisclosureType.PUBLIC,
 			board,
 			user
+		);
+	}
+
+	public static PostEntity generatePost(UserEntity user) {
+		return PostEntity.create(
+			"title_" + UUID.randomUUID(),
+			"content_" + UUID.randomUUID(),
+			PostDisclosureType.PUBLIC,
+			null,
+			user
+		);
+	}
+
+	public static PostEntity generatePost(BoardEntity board) {
+		return PostEntity.create(
+			"title_" + UUID.randomUUID(),
+			"content_" + UUID.randomUUID(),
+			PostDisclosureType.PUBLIC,
+			board,
+			null
 		);
 	}
 

--- a/src/test/java/com/kt/board/PostGenerator.java
+++ b/src/test/java/com/kt/board/PostGenerator.java
@@ -1,0 +1,31 @@
+package com.kt.board;
+
+import java.util.UUID;
+
+import com.kt.board.constants.PostDisclosureType;
+import com.kt.board.domain.entity.BoardEntity;
+import com.kt.board.domain.entity.PostEntity;
+import com.kt.board.domain.entity.UserEntity;
+
+public class PostGenerator {
+
+	public static PostEntity generatePost(String postTitle, BoardEntity board, UserEntity user) {
+		return PostEntity.create(
+			"title_" + UUID.randomUUID(),
+			"content_" + UUID.randomUUID(),
+			PostDisclosureType.PUBLIC,
+			board,
+			user
+		);
+	}
+
+	public static PostEntity generatePost() {
+		return PostEntity.create(
+			"title_" + UUID.randomUUID(),
+			"content_" + UUID.randomUUID(),
+			PostDisclosureType.PUBLIC,
+			null,
+			null
+		);
+	}
+}

--- a/src/test/java/com/kt/board/UserGenerator.java
+++ b/src/test/java/com/kt/board/UserGenerator.java
@@ -1,0 +1,20 @@
+package com.kt.board;
+
+import java.util.UUID;
+
+import com.kt.board.constants.Gender;
+import com.kt.board.constants.UserRole;
+import com.kt.board.domain.entity.UserEntity;
+
+public class UserGenerator {
+	public static UserEntity generateMemberUser() {
+		return UserEntity.create(
+			"user_" + UUID.randomUUID(),
+			"password",
+			Gender.MALE,
+			UUID.randomUUID() + "@test.com",
+			1,
+			UserRole.MEMBER
+		);
+	}
+}

--- a/src/test/java/com/kt/board/repository/post/PostRepositoryTest.java
+++ b/src/test/java/com/kt/board/repository/post/PostRepositoryTest.java
@@ -1,16 +1,28 @@
 package com.kt.board.repository.post;
 
+import static com.kt.board.BoardGenerator.*;
 import static com.kt.board.PostGenerator.*;
+import static com.kt.board.UserGenerator.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 
+import com.kt.board.domain.entity.BoardEntity;
+import com.kt.board.domain.entity.PostEntity;
+import com.kt.board.domain.entity.UserEntity;
 import com.kt.board.repository.BoardRepository;
 import com.kt.board.repository.PostRepository;
 import com.kt.board.repository.UserRepository;
 
-@DataJpaTest
+@SpringBootTest
+@ActiveProfiles("test")
 class PostRepositoryTest {
 
 	@Autowired
@@ -23,20 +35,66 @@ class PostRepositoryTest {
 	private PostRepository postRepository;
 
 	@Test
-	void 게시글_생성_실패__() {
+	void 게시글_생성_실패__board_and_user_null() {
 		// given
-		// UserEntity user = UserGenerator.generateMemberUser();
-		// userRepository.save(user);
-		// BoardEntity board = BoardGenerator.generateBoard(user);
-		// boardRepository.save(board);
-		//
-		// // when
-		// String title = "title_" + UUID.randomUUID();
-		// PostEntity post = generatePost(title, board, user);
+		PostEntity post = generatePost();
+		// when
 
 		// then
-		postRepository.save(generatePost());
-
+		assertThrowsExactly(
+			DataIntegrityViolationException.class, () -> {
+				postRepository.save(post);
+			}
+		);
 	}
 
+	@Test
+	void 게시글_생성_실패__board_null() {
+		// given
+		UserEntity user = generateMemberUser();
+		userRepository.save(user);
+		PostEntity post = generatePost(user);
+		// when
+
+		// then
+		assertThrowsExactly(
+			DataIntegrityViolationException.class, () -> {
+				postRepository.save(post);
+			}
+		);
+	}
+
+	@Test
+	void 게시글_생성_실패__user_null() {
+		// given
+		UserEntity user = generateMemberUser();
+		userRepository.save(user);
+		BoardEntity board = generateBoard(user);
+		boardRepository.save(board);
+		PostEntity post = generatePost(board);
+		// when
+
+		// then
+		assertThrowsExactly(
+			DataIntegrityViolationException.class, () -> {
+				postRepository.save(post);
+			}
+		);
+	}
+
+	@Test
+	void 게시글_생성_성공() {
+		// given
+		UserEntity user = generateMemberUser();
+		userRepository.save(user);
+		BoardEntity board = generateBoard(user);
+		boardRepository.save(board);
+		PostEntity post = generatePost(board, user);
+		// when
+		PostEntity saved = postRepository.save(post);
+		// then
+		Optional<PostEntity> found = postRepository.findById(saved.getId());
+		assertThat(found).isPresent();
+		assertThat(found.get().getTitle()).isEqualTo(post.getTitle());
+	}
 }

--- a/src/test/java/com/kt/board/repository/post/PostRepositoryTest.java
+++ b/src/test/java/com/kt/board/repository/post/PostRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.kt.board.repository.post;
+
+import static com.kt.board.PostGenerator.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.kt.board.repository.BoardRepository;
+import com.kt.board.repository.PostRepository;
+import com.kt.board.repository.UserRepository;
+
+@DataJpaTest
+class PostRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private BoardRepository boardRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Test
+	void 게시글_생성_실패__() {
+		// given
+		// UserEntity user = UserGenerator.generateMemberUser();
+		// userRepository.save(user);
+		// BoardEntity board = BoardGenerator.generateBoard(user);
+		// boardRepository.save(board);
+		//
+		// // when
+		// String title = "title_" + UUID.randomUUID();
+		// PostEntity post = generatePost(title, board, user);
+
+		// then
+		postRepository.save(generatePost());
+
+	}
+
+}

--- a/src/test/java/com/kt/board/repository/post/PostRepositoryTest.java
+++ b/src/test/java/com/kt/board/repository/post/PostRepositoryTest.java
@@ -93,8 +93,8 @@ class PostRepositoryTest {
 		// when
 		PostEntity saved = postRepository.save(post);
 		// then
-		Optional<PostEntity> found = postRepository.findById(saved.getId());
-		assertThat(found).isPresent();
-		assertThat(found.get().getTitle()).isEqualTo(post.getTitle());
+		Optional<PostEntity> foundPost = postRepository.findById(saved.getId());
+		assertThat(foundPost).isPresent();
+		assertThat(foundPost.get().getTitle()).isEqualTo(post.getTitle());
 	}
 }


### PR DESCRIPTION
게시글 레포 테스트 입니다.

게시글(Post)과 User, Board의 연관 관계에 따라 생성 과정에서 발생하는 문제를 테스트합니다.

BeforeEach를 사용하는 방법대신 객체별로 generate() 메소드를 만들고,

각 테스트 항목마다 초기화하는 방법으로 진행해봤습니다.

이렇게 할 경우 BeforeEach에서 테스트 항목 마다 분기 처리하지 않고,

테스트 항목 안에서 어떤 준비과정이 필요한지 더 가독성을 높일 수 있다고 생각합니다.