### PR TITLE
test: Reply Service Create 테스트

### DIFF
--- a/src/main/java/com/kt/board/constants/message/ErrorCode.java
+++ b/src/main/java/com/kt/board/constants/message/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
 	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시판은 존재하지 않습니다."),
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글은 존재하지 않습니다."),
-	REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글은 존재하지 않습니다.");
+	REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글은 존재하지 않습니다."),
+	REPLY_EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "댓글 내용이 비어있습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/kt/board/domain/entity/ReplyEntity.java
+++ b/src/main/java/com/kt/board/domain/entity/ReplyEntity.java
@@ -1,7 +1,11 @@
 package com.kt.board.domain.entity;
 
+import org.springframework.util.StringUtils;
+
 import com.kt.board.constants.ReplyStatus;
+import com.kt.board.constants.message.ErrorCode;
 import com.kt.board.domain.entity.common.BaseCreatedByEntity;
+import com.kt.board.exception.CustomException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -53,6 +57,9 @@ public class ReplyEntity extends BaseCreatedByEntity {
 		final PostEntity parentPost,
 		final UserEntity createdBy
 	) {
+		if (!StringUtils.hasText(content)) {
+			throw new CustomException(ErrorCode.REPLY_EMPTY_CONTENT);
+		}
 		return new ReplyEntity(content, parentPost, createdBy);
 	}
 

--- a/src/test/java/com/kt/board/service/reply/ReplyServiceCreateTest.java
+++ b/src/test/java/com/kt/board/service/reply/ReplyServiceCreateTest.java
@@ -1,0 +1,151 @@
+package com.kt.board.service.reply;
+
+import com.kt.board.constants.Gender;
+import com.kt.board.constants.PostDisclosureType;
+import com.kt.board.constants.UserRole;
+import com.kt.board.constants.message.ErrorCode;
+import com.kt.board.domain.dto.request.ReplyRequest;
+import com.kt.board.domain.entity.BoardEntity;
+import com.kt.board.domain.entity.PostEntity;
+import com.kt.board.domain.entity.ReplyEntity;
+import com.kt.board.domain.entity.UserEntity;
+import com.kt.board.exception.CustomException;
+import com.kt.board.repository.BoardRepository;
+import com.kt.board.repository.PostRepository;
+import com.kt.board.repository.ReplyRepository;
+import com.kt.board.repository.UserRepository;
+import com.kt.board.service.ReplyService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ReplyServiceCreateTest {
+
+	@Autowired
+	ReplyService replyService;
+
+	@Autowired
+	ReplyRepository replyRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	BoardRepository boardRepository;
+
+	@Autowired
+	PostRepository postRepository;
+
+	UserEntity user;
+	PostEntity post;
+	BoardEntity board;
+
+	@BeforeEach
+	void setUp() {
+		user = userRepository.save(
+			UserEntity.create(
+				"테스터",
+				"123123!@#",
+				Gender.MALE,
+				"test@gmail.com",
+				26,
+				UserRole.MEMBER
+			)
+		);
+
+		board = boardRepository.save(
+			BoardEntity.create(
+				"테스트 게시판 이름",
+				user
+			)
+		);
+
+		post = postRepository.save(
+			PostEntity.create(
+				"테스트 게시글 제목",
+				"테스트 게시글 내용",
+				PostDisclosureType.PUBLIC,
+				board,
+				user
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("댓글_생성_성공")
+	void 댓글_생성_성공() {
+		ReplyRequest.Create request = new ReplyRequest.Create(
+			"테스트 댓글 내용",
+			user.getId()
+		);
+
+		replyService.create(post.getId(), request);
+
+		ReplyEntity savedReply = replyRepository.findAll().getFirst();
+
+		assertThat(savedReply.getContent()).isEqualTo("테스트 댓글 내용");
+		assertThat(savedReply.getParentPost().getId()).isEqualTo(post.getId());
+		assertThat(savedReply.getCreatedBy().getId()).isEqualTo(user.getId());
+	}
+
+	@Test
+	@DisplayName("댓글_생성_실패__게시글없음")
+	void 댓글_생성_실패__게시글없음() {
+		ReplyRequest.Create request = new ReplyRequest.Create(
+			"댓글 내용",
+			user.getId()
+		);
+
+		CustomException ex = assertThrows(CustomException.class, () ->
+			replyService.create(999999L, request)
+		);
+
+		assertThat(ex.getError()).isEqualTo(ErrorCode.POST_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("댓글_생성_실패__유저없음")
+	void 댓글_생성_실패__유저없음() {
+		ReplyRequest.Create request = new ReplyRequest.Create(
+			"댓글 내용",
+			999999L
+		);
+
+		CustomException ex = assertThrows(CustomException.class, () ->
+			replyService.create(post.getId(), request)
+		);
+
+		assertThat(ex.getError()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {"   "})
+	@DisplayName("댓글_생성_실패__내용_null_공백")
+	void 댓글_생성_실패__내용_null_공백(String content) {
+		ReplyRequest.Create request = new ReplyRequest.Create(
+			content,
+			user.getId()
+		);
+
+		CustomException ex = assertThrows(CustomException.class, () ->
+			replyService.create(post.getId(), request)
+		);
+
+		assertThat(ex.getError()).isEqualTo(ErrorCode.REPLY_EMPTY_CONTENT);
+	}
+
+}


### PR DESCRIPTION
* given - when - then 패턴을 따르도록 구성했습니다
* 일단은 ReplyEntity.create에 validation 추가해서 테스트 진행했습니다!

## 주요 테스트 항목
### 1. 댓글 생성 성공
- content, 생성 유저, 연결된 게시글 모두 정상 매핑되는지 확인

### 2. 댓글 생성 실패 
**2.1 게시글 없음**
- 존재하지 않는 postId로 create 호출시CustomException 발생 검사

**2.2 유저 없음**
- 존재하지 않는 userId로 create 호출시 CustomException 발생 검사

**2.3 댓글 내용 없음**
- ErrorCode에 REPLY_EMPTY_CONTENT 추가 
- StringUtils.hasText() validation 추가
- ValueSource로 null, blank 한번에 검사
---
### 논의 사항
다른 분들과 마찬가지로 Entity에 if문을 작성하였는데, 내일 컨벤션 정의 후 수정이 필요할 것 같습니다