### PR TITLE
test: Reply Service Update 테스트

### DIFF
--- a/src/main/java/com/kt/board/constants/message/ErrorCode.java
+++ b/src/main/java/com/kt/board/constants/message/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
 	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시판은 존재하지 않습니다."),
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글은 존재하지 않습니다."),
-	REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글은 존재하지 않습니다.");
+	REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글은 존재하지 않습니다."),
+	REPLY_EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "댓글 내용이 비어있습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/kt/board/domain/entity/ReplyEntity.java
+++ b/src/main/java/com/kt/board/domain/entity/ReplyEntity.java
@@ -1,7 +1,11 @@
 package com.kt.board.domain.entity;
 
+import org.springframework.util.StringUtils;
+
 import com.kt.board.constants.ReplyStatus;
+import com.kt.board.constants.message.ErrorCode;
 import com.kt.board.domain.entity.common.BaseCreatedByEntity;
+import com.kt.board.exception.CustomException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -30,6 +34,9 @@ public class ReplyEntity extends BaseCreatedByEntity {
 	private PostEntity parentPost;
 
 	public void update(String content) {
+		if (!StringUtils.hasText(content)) {
+			throw new CustomException(ErrorCode.REPLY_EMPTY_CONTENT);
+		}
 		this.content = content;
 	}
 

--- a/src/test/java/com/kt/board/service/reply/ReplyServiceUpdateTest.java
+++ b/src/test/java/com/kt/board/service/reply/ReplyServiceUpdateTest.java
@@ -1,0 +1,145 @@
+package com.kt.board.service.reply;
+
+import com.kt.board.constants.Gender;
+import com.kt.board.constants.PostDisclosureType;
+import com.kt.board.constants.UserRole;
+import com.kt.board.constants.message.ErrorCode;
+import com.kt.board.domain.dto.request.ReplyRequest;
+import com.kt.board.domain.entity.BoardEntity;
+import com.kt.board.domain.entity.PostEntity;
+import com.kt.board.domain.entity.ReplyEntity;
+import com.kt.board.domain.entity.UserEntity;
+import com.kt.board.exception.CustomException;
+import com.kt.board.repository.BoardRepository;
+import com.kt.board.repository.PostRepository;
+import com.kt.board.repository.ReplyRepository;
+import com.kt.board.repository.UserRepository;
+import com.kt.board.service.ReplyService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ReplyServiceUpdateTest {
+
+	@Autowired
+	ReplyService replyService;
+
+	@Autowired
+	ReplyRepository replyRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	BoardRepository boardRepository;
+
+	@Autowired
+	PostRepository postRepository;
+
+	UserEntity user;
+	BoardEntity board;
+	PostEntity post;
+	ReplyEntity reply;
+
+	@BeforeEach
+	void setUp() {
+
+		user = userRepository.save(
+			UserEntity.create(
+				"테스터",
+				"1234!@#",
+				Gender.MALE,
+				"update@test.com",
+				26,
+				UserRole.MEMBER
+			)
+		);
+
+		board = boardRepository.save(
+			BoardEntity.create(
+				"수정 게시판",
+				user
+			)
+		);
+
+		post = postRepository.save(
+			PostEntity.create(
+				"수정 게시글 제목",
+				"내용",
+				PostDisclosureType.PUBLIC,
+				board,
+				user
+			)
+		);
+
+		reply = replyRepository.save(
+			ReplyEntity.create(
+				"기존 댓글 내용",
+				post,
+				user
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("댓글_수정_성공")
+	void 댓글_수정_성공() {
+		ReplyRequest.Update request = new ReplyRequest.Update(
+			"수정된 댓글 내용",
+			user.getId()
+		);
+
+		replyService.update(reply.getId(), request);
+
+		ReplyEntity updated = replyRepository.findById(reply.getId())
+			.orElseThrow();
+
+		assertThat(updated.getContent()).isEqualTo("수정된 댓글 내용");
+	}
+
+	@Test
+	@DisplayName("댓글_수정_실패__replyId_없음")
+	void 댓글_수정_실패__replyId_없음() {
+
+		ReplyRequest.Update request = new ReplyRequest.Update(
+			"수정 내용",
+			user.getId()
+		);
+
+		CustomException ex = assertThrows(CustomException.class, () ->
+			replyService.update(999999L, request)
+		);
+
+		assertThat(ex.getError()).isEqualTo(ErrorCode.REPLY_NOT_FOUND);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {"   "})
+	@DisplayName("댓글_수정_실패__내용_null_공백")
+	void 댓글_수정_실패__내용_null_공백(String content) {
+		ReplyRequest.Update request = new ReplyRequest.Update(
+			content,
+			user.getId()
+		);
+
+		CustomException ex = assertThrows(CustomException.class, () ->
+			replyService.update(reply.getId(), request)
+		);
+
+		assertThat(ex.getError()).isEqualTo(ErrorCode.REPLY_EMPTY_CONTENT);
+	}
+}


### PR DESCRIPTION
## 주요 테스트 항목
### 1. 댓글 수정 성공
- 기존 댓글의 content가 정상적으로 새로운 값으로 변경되는지 검사

### 2. 댓글 수정 실패
**2.1 댓글 없음**
- 존재하지 않는 replyId로 update 호출시, CustomException 발생 검사

**2.2 댓글 내용 없음**
- ValueSource로 null, blank 한번에 검사